### PR TITLE
Bugfix: Clear saved text in the dom when clicking Clear button

### DIFF
--- a/src/browser_actions/popup.js
+++ b/src/browser_actions/popup.js
@@ -76,6 +76,7 @@ const performSearch = (searchText) => {
 
 const onResetClick = () => {
     chrome.runtime.sendMessage({ clear: true });
+    renderClippings();
 }
 
 const onClipClick = (e) => {


### PR DESCRIPTION
Resolves https://github.com/saifabusaleh/clipboard-history-extension/issues/9

Prior to this change, when a user clicked the Clear saved text button we cleared the clippings list. However, the DOM didn't reflext the change and continued to display the list of clippings. This adds a line to update the DOM as well as send the clear message to chrome.runtime. This way, the user gets immediate feedback for their action.

Before: 
![possible-bug-report](https://user-images.githubusercontent.com/16784959/95663369-9ae88000-0b36-11eb-8cba-6dda7c47ae3f.gif)


After: 
![fix](https://user-images.githubusercontent.com/16784959/95663365-945a0880-0b36-11eb-8996-f9854e6d2828.gif)
