### PR TITLE
BugFix for two clippings get removed instead of one when removing clip

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -50,7 +50,7 @@ const getClippings = (request, sendResponse) => {
     chrome.storage.sync.get("clippings", (result) => {
         let clippings = result.clippings || [];
         if (request.selection) {
-            clippings = [...clippings, { text: request.selection, creationDate: new Date().toLocaleString() }];
+            clippings = [...clippings, { text: request.selection, creationDate: new Date().getTime() }];
         }
         chrome.storage.sync.set({ clippings }, () => {
             sendResponse({ clippings });

--- a/src/browser_actions/popup.js
+++ b/src/browser_actions/popup.js
@@ -58,7 +58,7 @@ const createClipTextElement = (text) => {
 
 const createClipDateElement = (creationDate) => {
     const dateDiv = document.createElement("div");
-    dateDiv.textContent = creationDate;
+    dateDiv.textContent = new Date(creationDate).toLocaleString();
     dateDiv.className = "creation-date";
     return dateDiv;
 }
@@ -182,11 +182,12 @@ const setDarkTheme = () => {
 
 const exportJson = () => {
     let clipboardHistory = []
+    const readableClippingsList = clippingsList.map(clip => ({ ...clip, creationDate: new Date(clip.creationDate).toLocaleString() }))
     if (!searchText) {
-        clipboardHistory = JSON.stringify(clippingsList);
+        clipboardHistory = JSON.stringify(readableClippingsList, null, 2);
     } else {
-        const filteredList = filterClippingsList(clippingsList, searchText);
-        clipboardHistory = JSON.stringify(filteredList);
+        const filteredList = filterClippingsList(readableClippingsList, searchText);
+        clipboardHistory = JSON.stringify(filteredList, null, 2);
     }
     const exportLink = document.createElement("a");
     var exportBlob = new Blob([clipboardHistory], { type: "octet/stream" });
@@ -197,3 +198,4 @@ const exportJson = () => {
     exportLink.setAttribute("download", exportFileName);
     exportLink.click();
 }
+


### PR DESCRIPTION
Fix for https://github.com/saifabusaleh/clipboard-history-extension/issues/26
The issue was that the clips were using the timestamp as the unique identifier, particularly during deletion. However, the timestamp generated with toLocaleString is in format MM/DD/YYYY, HH:MM:SS AM/PM. This means that if two clips were made very quickly, within the same second, they would have the same timestamp. And therefore, removing one would remove the other
My suggested fix is to use the true UTC timestamp as the "creationDate" for clips and as the unique identifier. This is in milliseconds therefore two clips will never have the same creationDate. And only for displaying it do we go back to calling toLocaleString