### PR TITLE
[Bug] Removing a clip reverses the order of clips in display

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -50,7 +50,7 @@ const getClippings = (request, sendResponse) => {
     chrome.storage.sync.get("clippings", (result) => {
         let clippings = result.clippings || [];
         if (request.selection) {
-            clippings = [...clippings, { text: request.selection, creationDate: new Date().getTime() }];
+            clippings = [{ text: request.selection, creationDate: new Date().getTime() }, ...clippings];
         }
         chrome.storage.sync.set({ clippings }, () => {
             sendResponse({ clippings });

--- a/src/browser_actions/popup.js
+++ b/src/browser_actions/popup.js
@@ -140,7 +140,7 @@ const onClipClick = (e) => {
 
 const renderClippingOnLoad = () => {
     chrome.runtime.sendMessage({}, (response) => {
-        clippingsList = response.clippings.reverse();
+        clippingsList = response.clippings;
         renderClippings(response.clippings);
     });
 }


### PR DESCRIPTION
Fix for https://github.com/saifabusaleh/clipboard-history-extension/issues/28

 Save clips list in order such that newest is at top